### PR TITLE
Fix group permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN \
         /etc/services.d/php-fpm7/supervise/control \
         /etc/s6/services/s6-fdholderd/supervise/control \
     && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
+    && adduser nobody www-data \
     && chown -R nobody.www-data /etc/services.d /etc/s6 /run /srv/* /var/lib/nginx /var/www \
 # Clean up
     && rm -rf "${GNUPGHOME}" /tmp/* \


### PR DESCRIPTION
The user `nobody` isn't in the group `www-data` which leads to php-fpm attempting to chown the socket but this fails with;
```ERROR: [pool www] failed to chown() the socket '/run/php-fpm.sock': Operation not permitted (1)```

Also updated nginx.conf for consistency but this is also ignored because the container doesn't start as root by default.
```the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /etc/nginx/nginx.conf:2```


Environment is;
Ubuntu 16.04.6 LTS   4.4.0-1095-aws   docker://18.6.2