### PR TITLE
ci: deploy nightly built multi-architecture images

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,74 @@
+name: Deploy multi-architecture Docker images for privatebin with buildx
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # everyday at midnight UTC
+  pull_request:
+    branches: master
+  push:
+    branches: master
+    tags:
+      - *
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Prepare
+        id: prepare
+        run: |
+          DOCKER_IMAGE=privatebin/nginx-fpm-alpine
+          DOCKER_PLATFORMS=linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/386,linux/ppc64le
+          VERSION=edge
+
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          fi
+
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            VERSION=nightly
+          fi
+
+          TAGS="--tag ${DOCKER_IMAGE}:${VERSION}"
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            TAGS="$TAGS --tag ${DOCKER_IMAGE}:latest"
+          fi
+
+          echo ::set-output name=docker_image::${DOCKER_IMAGE}
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=buildx_args::--platform ${DOCKER_PLATFORMS} \
+            ${TAGS} .
+      -
+        name: Set up Docker Buildx
+        uses: crazy-max/ghaction-docker-buildx@v3
+      -
+        name: Docker Buildx (build)
+        run: |
+          docker buildx build --no-cache --pull --output "type=image,push=false" ${{ steps.prepare.outputs.buildx_args }}
+      -
+        name: Docker Login
+        if: success() && github.event_name != 'pull_request'
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+      -
+        name: Docker Buildx (push)
+        if: success() && github.event_name != 'pull_request'
+        run: |
+          docker buildx build --output "type=image,push=true" ${{ steps.prepare.outputs.buildx_args }}
+      -
+        name: Docker Check Manifest
+        if: always() && github.event_name != 'pull_request'
+        run: |
+          docker run --rm mplatform/mquery ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
+      -
+        name: Clear
+        if: always() && github.event_name != 'pull_request'
+        run: |
+          rm -f ${HOME}/.docker/config.json


### PR DESCRIPTION
This PR add automated builds for the `privatebin/nginx-fpm-alpine` image using [this](https://github.com/marketplace/actions/docker-buildx) GitHub action which in turn uses [`docker buildx`](https://docs.docker.com/buildx/working-with-buildx/).

These builds (and sometimes pushes) will happen on 3 different events:

* pushes to master on `PrivateBin/docker-nginx-fpm-alpine` (built and pushed as `privatebin/nginx-fpm-alpine:edge` and `privatebin/nginx-fpm-alpine:latest`)
* every night at midnight UTC to pull in updates in the `alpine` image and the software installed during image build (built and pushed as `privatebin/nginx-fpm-alpine:nightly` and `privatebin/nginx-fpm-alpine:latest`)
* on pull requests (just built)

The images will be built for the following architectures:

* x86 (i386)
* x86_64 (amd64)
* armv6
* armv7
* armv8 (aarch64/arm64)
* ppc64le

In order to test them (I only tested x86_64 and aarch64), I built all the images.

If someone wants to test another one, you can find them [here](https://hub.docker.com/r/zuh0/nginx-fpm-alpine).

For these automated builds to be pushed, 2 secrets would have to be added to the `PrivateBin/docker-nginx-fpm-alpine` GitHub repository.

The first one called DOCKER_USERNAME should be the Docker hub username for the "privatebin" account.

The second one called DOCKER_PASSWORD should be an access token generated on Docker hub like explained [here](https://docs.docker.com/docker-hub/access-tokens/).

This would resolve #17 .