### PR TITLE
do not start nginx until /var/run/php-fpm.sock is available

### DIFF
--- a/etc/s6/services/nginx/run
+++ b/etc/s6/services/nginx/run
@@ -1,2 +1,3 @@
 #!/usr/bin/execlineb -P
+if { test -S /var/run/php-fpm.sock }
 /usr/sbin/nginx


### PR DESCRIPTION
closes #42

# Changes
- add test for existence of the pipe /var/run/php-fpm.sock