### PR TITLE
Disable Snyk for PRs

### DIFF
--- a/.github/workflows/snyk-container-analysis.yml
+++ b/.github/workflows/snyk-container-analysis.yml
@@ -13,7 +13,7 @@ on:
     branches: [ master ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    #branches: [ master ]
   schedule:
     - cron: '23 7 * * 5'
 


### PR DESCRIPTION
As noticed in https://github.com/PrivateBin/docker-nginx-fpm-alpine/pull/52#issuecomment-875021973 Sync fails in PRs.

It says:
> `snyk` requires an authenticated account. Please run `snyk auth` and try again.

Basically, it's the token secret it cannot (and of course also should not) access.
As such, I'd say we disable it for PRs…

https://github.com/PrivateBin/docker-nginx-fpm-alpine/pull/52/checks?check_run_id=3002306667