### PR TITLE
Fix reference to port on liveness and readiness probes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,11 @@ spec:
         livenessProbe:
           httpGet:
             path: /
-            port: http
+            port: 8080
         readinessProbe:
           httpGet:
             path: /
-            port: http
+            port: 8080
         volumeMounts:
         - mountPath: /srv/data
           name: privatebin-data


### PR DESCRIPTION
Hello,

I found that the Kubernetes manifest provided as an example on the readme file contains an error on the reference to the port. Specifically, on the liveness and readiness section. I just updated the port on both for pointing to the 8080. Another possibility for fixing this could be just declaring the following on the "ports" section of the container "privatebin":
```yaml
ports:
  - name: http
    containerPort: 8080
    protocol: TCP
```

Thank you in advance!


Regards