### PR TITLE
handle corner case deleting temporary files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN \
 # Ensure nginx logs, even if the config has errors, are written to stderr
     && ln -s /dev/stderr /var/log/nginx/error.log \
 # Install PrivateBin
-    && export GNUPGHOME="$(mktemp -d)" \
+    && export GNUPGHOME="$(mktemp -d -p /tmp)" \
     && gpg2 --list-public-keys || /bin/true \
     && wget -qO - https://privatebin.info/key/release.asc | gpg2 --import - \
     && rm -rf /var/www/* \
@@ -76,7 +76,7 @@ RUN \
     && chown -R ${UID}:${GID} /etc/s6 /run /srv/* /var/lib/nginx /var/www \
     && chmod o+rwx /run /var/lib/nginx /var/lib/nginx/tmp \
 # Clean up
-    && rm -rf "${GNUPGHOME}" /tmp/* \
+    && rm -rf /tmp/* \
     && apk del --no-cache gnupg git ${ALPINE_COMPOSER_PACKAGES}
 
 COPY etc/ /etc/


### PR DESCRIPTION
I've been reviewing the errors in the nightly and PR image builds of the last days. The nightlys failed in edge with errors downloading packages like these:
```
#27 0.115 fetch https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz
#27 0.338 fetch https://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz
#27 0.871 Upgrading critical system libraries and apk-tools:
#27 0.872 (1/8) Purging ssl_client (1.33.1-r4)
#27 0.873 (2/8) Installing libcrypto3 (3.0.0-r0)
#27 0.945 (3/8) Installing libssl3 (3.0.0-r0)
#27 0.968 (4/8) Upgrading apk-tools (2.12.7-r0 -> 2.12.7-r1)
#27 1.088 (5/8) Purging libretls (3.3.3p1-r0)
#27 1.088 (6/8) Purging ca-certificates-bundle (20191127-r5)
#27 1.090 (7/8) Purging libssl1.1 (1.1.1k-r1)
#27 1.090 (8/8) Purging libcrypto1.1 (1.1.1k-r1)
#27 1.092 Executing busybox-1.33.1-r4.trigger
#27 1.223 Continuing the upgrade transaction with new apk-tools:
#27 1.233 fetch https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz
#27 1.259 486B20A1F77F0000:error:0A000086:SSL routines:tls_post_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:1882:
#27 1.264 WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/edge/main: Permission denied
#27 1.269 fetch https://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz
#27 1.314 486B20A1F77F0000:error:0A000086:SSL routines:tls_post_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:1882:
#27 1.315 WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/edge/community: Permission denied
#27 1.327 OK: 7 MiB in 11 packages
#27 1.341 fetch https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz
#27 1.371 48AB31BFF97F0000:error:0A000086:SSL routines:tls_post_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:1882:
#27 1.372 WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/edge/main: Permission denied
#27 1.374 fetch https://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz
#27 1.398 48AB31BFF97F0000:error:0A000086:SSL routines:tls_post_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:1882:
#27 1.406 WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/edge/community: Permission denied
```
I suspect the purged ssl_client is used by busybox wget and the upgrade of apk-tools triggers a re-download of the package database, but before the new ssl_client gets installed and so that fails. This should be resolved when they rebuild the "edge" base image or an actual issue with their repositories TLS setup or certificate. Alternatively we can explicitly update the apk-tools first, then everything else (like they [instruct to do when doing a release upgrade](https://wiki.alpinelinux.org/wiki/Upgrading_Alpine#Upgrading_packages)).

This change is for the other corner case I've seen. The command and error look like this:
```
rm -rf "${GNUPGHOME}" /tmp/*
rm: can't remove '/tmp/tmp.lEmcDl/S.gpg-agent.ssh': No such file or directory
```
That error indicates that (busybox) rm tries to delete that file after the folder already got deleted. In GNU rm the `-f/--force` flag would suppress such errors (it would report to STDERR, but not exit > 0). I failed to reproduce this behaviour in either alpine 3.14 or edge, but my development environment is x86_64 and the error above occurred in a armhf one, so maybe this bug is architecture dependent - it may also be in the argument expansion done by the busybox /bin/sh rather then it's rm implementation.

My change is twofold:
1. ensure that `${GNUPGHOME}` is created within `/tmp` (according to `mktemp --help`, the "Base directory is: -p DIR, else $TMPDIR, else /tmp", so I set it explicitly, in case $TMPDIR would get changed, later on)
2. remove `${GNUPGHOME}` from the `rm` as `/tmp/*` already expands to it

This should ensure that the folder is only listed once in the `rm` parameters and hopefully avoids this issue.