### PR TITLE
edge build: deal with ssl_client while busybox gets migrated to openssl 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN \
 # Install dependencies
     && apk upgrade --no-cache \
     && apk add --no-cache gnupg git nginx php8-fpm php8-json php8-gd php8-opcache \
-        s6 tzdata ${ALPINE_PACKAGES} ${ALPINE_COMPOSER_PACKAGES} \
+        s6 ssl_client tzdata ${ALPINE_PACKAGES} ${ALPINE_COMPOSER_PACKAGES} \
 # Remove (some of the) default nginx config
     && rm -f /etc/nginx.conf /etc/nginx/http.d/default.conf /etc/php8/php-fpm.d/www.conf \
     && rm -rf /etc/nginx/sites-* \
@@ -77,7 +77,7 @@ RUN \
     && chmod o+rwx /run /var/lib/nginx /var/lib/nginx/tmp \
 # Clean up
     && rm -rf /tmp/* \
-    && apk del --no-cache gnupg git ${ALPINE_COMPOSER_PACKAGES}
+    && apk del --no-cache gnupg git ssl_client ${ALPINE_COMPOSER_PACKAGES}
 
 COPY etc/ /etc/
 


### PR DESCRIPTION
An earlier issue (#68 - the first described issue) with a [dependency of the package manager in edge got solved upstream](https://gitlab.alpinelinux.org/alpine/aports/-/issues/13022#note_181802). Now we hit the next problem with busybox still using ssl_client, but that already got removed from it's dependencies in the process to upgrade it to openssl 3, resulting in:

```
# during: wget -qO - https://privatebin.info/key/release.asc | gpg2 --import -
#31 6.836 wget: can't execute 'ssl_client': No such file or directory
#31 6.837 wget: error getting response: Connection reset by peer
```

ssl_client will become obsolete when busybox gets migrated to openssl 3, but for now we need to still add it explicitly for current alpine edge, while this is being worked on. For the main release (3.14), this change causes warnings that it is already installed and that it can't be uninstalled, since it is still depended on.

This change will allow the edge builds to succeed again (until other things break in there). Once ssl_client is no longer used, we can just `git revert`this change to remove this extra package again.