### PR TITLE
ensure gpg-agent is dead, before deleting the $GNUPGHOME

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ RUN \
     && chown -R ${UID}:${GID} /etc/s6 /run /srv/* /var/lib/nginx /var/www \
     && chmod o+rwx /run /var/lib/nginx /var/lib/nginx/tmp \
 # Clean up
+    && gpgconf --kill gpg-agent \
     && rm -rf /tmp/* \
     && apk del --no-cache gnupg git ssl_client ${ALPINE_COMPOSER_PACKAGES}
 


### PR DESCRIPTION
I looked at yet another failed build run and it again occurred in the armv7 build of an edge image, same as in #68:

```
#27 43.28 rm: can't remove '/tmp/tmp.EdnMEJ/S.gpg-agent.extra': No such file or directory
```

That seemed like a bit more than a coincidence and I found [this very similar report](https://github.com/MatthewVance/nginx-build/issues/33) that might explain this. It, too, occurs in an armv7 environment (Raspberry Pi 2), but on Raspbian Stretch and with gpg 2. To quote their analysis:

> It seems gpg automatically starts gpg-agent and this behaviour cannot be disabled using the --no-use-agent option in GnuPG 2.x, as explained in the docs:
> 
> > `--use-agent`
> > `--no-use-agent`
> > This is dummy option. gpg always requires the agent.
> 
> gpg-agent creates the three sockets in $GNUPGHOME, as above.
> At the time the script subsequently tries to clean up the temp folder (using rm -f), the sockets are still there, and rm thus complains that it can't delete them, as shown in the above error output. (The sockets are certainly gone by the time I try looking for them after the script has exited on failure though!)
> 
> I've found that the error goes away if I specifically quit the gpg-agent process before attempting to delete the temp folder, by adding a gpgconf --kill gpg-agent line immediately before the rm -r "$GNUPGHOME" OPENSSL.tar.gz.asc NGINX.tar.gz.asc line.

This PR adds that suggested command to avoid this scenario.