### PR TITLE
run all image builds in parallel, letting all builds conclude

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,4 +1,4 @@
-name: Deploy multi-architecture Docker images for privatebin with buildx
+name: Build & Deploy container image
 
 on:
   schedule:
@@ -15,8 +15,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [stable, edge]
-    name: Build images based on ${{ matrix.image }} Alpine release
+        base-image: [stable, edge]
+        destination-image: [nginx-fpm-alpine, fs, pdo, gcs]
+    name: ${{ matrix.destination-image }} image / ${{ matrix.base-image }} release
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -32,4 +33,4 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: ./buildx.sh ${{ github.event_name }} ${{ matrix.image }}
+        run: ./buildx.sh ${{ github.event_name }} ${{ matrix.destination-image }} ${{ matrix.base-image }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -12,6 +12,11 @@ on:
 jobs:
   buildx:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [stable, edge]
+    name: Build images based on ${{ matrix.image }} Alpine release
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -27,4 +32,4 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: ./buildx.sh ${{ github.event_name }}
+        run: ./buildx.sh ${{ github.event_name }} ${{ matrix.image }}

--- a/buildx.sh
+++ b/buildx.sh
@@ -59,10 +59,14 @@ main() {
         PUSH=false
     fi
 
-    sed -e 's/^FROM alpine:.*$/FROM alpine:edge/' Dockerfile > Dockerfile.edge
-
     image_build_arguments | while read -r IMAGE BUILD_ARGS ; do
         build_image $PUSH --tag "$IMAGE:latest" --tag "$IMAGE:$TAG" --tag "${IMAGE}:${TAG%%-*}" "$BUILD_ARGS"
+    done
+
+    # run the edge builds in a separate loop, to avoid issues in them from
+    # preventing the stable image builds and pushes to conclude
+    sed -e 's/^FROM alpine:.*$/FROM alpine:edge/' Dockerfile > Dockerfile.edge
+    image_build_arguments | while read -r IMAGE BUILD_ARGS ; do
         build_image $PUSH -f Dockerfile.edge    --tag "$IMAGE:edge" "$BUILD_ARGS"
     done
 

--- a/buildx.sh
+++ b/buildx.sh
@@ -5,8 +5,9 @@
 set -euxo pipefail
 
 EVENT=$1
+IMAGE=$2
 EDGE=false
-[ "$2" = edge ] && EDGE=true
+[ "$3" = edge ] && EDGE=true
 
 build_image() {
     local PUSH
@@ -29,15 +30,6 @@ docker_login() {
         --password-stdin
 }
 
-image_build_arguments() {
-    cat<<!
-privatebin/fs  --build-arg ALPINE_PACKAGES= --build-arg COMPOSER_PACKAGES=
-privatebin/pdo --build-arg ALPINE_PACKAGES=php8-pdo_mysql,php8-pdo_pgsql --build-arg COMPOSER_PACKAGES=
-privatebin/gcs --build-arg ALPINE_PACKAGES=php8-openssl
-privatebin/nginx-fpm-alpine
-!
-}
-
 is_image_push_required() {
     [ "$EVENT" != pull_request ] && { \
         [ "$GITHUB_REF" != refs/heads/master ] || \
@@ -46,7 +38,7 @@ is_image_push_required() {
 }
 
 main() {
-    local PUSH TAG IMAGE BUILD_ARGS
+    local PUSH TAG BUILD_ARGS
 
     if [ "$EVENT" = schedule ] ; then
         TAG=nightly
@@ -61,16 +53,28 @@ main() {
         PUSH=false
     fi
 
-    if [ "$EDGE" = true ] ; then
+    case "$IMAGE" in
+        fs)
+            BUILD_ARGS="--build-arg ALPINE_PACKAGES= --build-arg COMPOSER_PACKAGES="
+            ;;
+        pdo)
+            BUILD_ARGS="--build-arg ALPINE_PACKAGES=php8-pdo_mysql,php8-pdo_pgsql --build-arg COMPOSER_PACKAGES="
+            ;;
+        gcs)
+            BUILD_ARGS="--build-arg ALPINE_PACKAGES=php8-openssl"
+            ;;
+        *)
+            BUILD_ARGS=""
+            ;;
+    esac
+    IMAGE="privatebin/$IMAGE"
+
+    if [ "$EDGE" = false ] ; then
+        build_image $PUSH --tag "$IMAGE:latest" --tag "$IMAGE:$TAG" --tag "${IMAGE}:${TAG%%-*}" "$BUILD_ARGS"
+    else
         sed -e 's/^FROM alpine:.*$/FROM alpine:edge/' Dockerfile > Dockerfile.edge
+        build_image $PUSH -f Dockerfile.edge    --tag "$IMAGE:edge" "$BUILD_ARGS"
     fi
-    image_build_arguments | while read -r IMAGE BUILD_ARGS ; do
-        if [ "$EDGE" = false ] ; then
-            build_image $PUSH --tag "$IMAGE:latest" --tag "$IMAGE:$TAG" --tag "${IMAGE}:${TAG%%-*}" "$BUILD_ARGS"
-        else
-            build_image $PUSH -f Dockerfile.edge    --tag "$IMAGE:edge" "$BUILD_ARGS"
-        fi
-    done
 
     rm -f Dockerfile.edge "$HOME/.docker/config.json"
 }

--- a/buildx.sh
+++ b/buildx.sh
@@ -69,11 +69,11 @@ main() {
     esac
     IMAGE="privatebin/$IMAGE"
 
-    if [ "$EDGE" = false ] ; then
-        build_image $PUSH --tag "$IMAGE:latest" --tag "$IMAGE:$TAG" --tag "${IMAGE}:${TAG%%-*}" "$BUILD_ARGS"
-    else
+    if [ "$EDGE" = true ] ; then
         sed -e 's/^FROM alpine:.*$/FROM alpine:edge/' Dockerfile > Dockerfile.edge
         build_image $PUSH -f Dockerfile.edge    --tag "$IMAGE:edge" "$BUILD_ARGS"
+    else
+        build_image $PUSH --tag "$IMAGE:latest" --tag "$IMAGE:$TAG" --tag "${IMAGE}:${TAG%%-*}" "$BUILD_ARGS"
     fi
 
     rm -f Dockerfile.edge "$HOME/.docker/config.json"


### PR DESCRIPTION
As per an [earlier discussion](https://github.com/PrivateBin/docker-nginx-fpm-alpine/pull/70#issuecomment-928761214), we:
- do want edge build failures to be noticed, so we can fix issues preventively, before they hit us in an upgrade
- but would like to avoid them from preventing the stable image builds to get pushed, i.e. in the nightly image builds

Hence this PR suggests to move the edge builds into a second loop, after the stable builds. Failures in them will still cause the whole build to fail.