### PR TITLE
Add Cache-Control header with no-transform directive

### DIFF
--- a/etc/nginx/http.d/site.conf
+++ b/etc/nginx/http.d/site.conf
@@ -18,6 +18,14 @@ server {
         try_files $uri $uri/ /index.php$is_args$args;
     }
 
+    location ~ \.js$ {
+        # no-transform tells Cloudflare and others to not change the content of
+        # the file and thus breaking SRI.
+        # https://developers.cloudflare.com/cache/about/cache-control#other
+        add header Cache-Control "public, max-age=3600, must-revalidate, no-transform";
+        try_files $uri $uri/ =404;
+    }
+
     location ~ \.php$ {
         include /etc/nginx/location.d/*.conf;
         fastcgi_pass unix:/run/php-fpm.sock;


### PR DESCRIPTION
This should avoid that proxies like Cloudflare and others break SRI.

Signed-off-by: Sylvain Rabot <sylvain@abstraction.fr>