### PR TITLE
Fix syntax error in nginx config

### DIFF
--- a/etc/nginx/http.d/site.conf
+++ b/etc/nginx/http.d/site.conf
@@ -22,7 +22,7 @@ server {
         # no-transform tells Cloudflare and others to not change the content of
         # the file and thus breaking SRI.
         # https://developers.cloudflare.com/cache/about/cache-control#other
-        add header Cache-Control "public, max-age=3600, must-revalidate, no-transform";
+        add_header Cache-Control "public, max-age=3600, must-revalidate, no-transform";
         try_files $uri $uri/ =404;
     }
 


### PR DESCRIPTION
This prevented the startup of the nginx server and thus the container.

Fixes https://github.com/PrivateBin/docker-nginx-fpm-alpine/issues/75