### PR TITLE
move Cache-Control header to server block, remove js location block

### DIFF
--- a/etc/nginx/http.d/site.conf
+++ b/etc/nginx/http.d/site.conf
@@ -5,19 +5,22 @@ server {
     root /var/www;
     index index.php index.html index.htm;
 
-    # no-transform tells Cloudflare and others to not change the content of
-    # the file and thus breaking SRI.
-    # https://developers.cloudflare.com/cache/about/cache-control#other
-    add_header Cache-Control "public, max-age=3600, must-revalidate, no-transform";
-    add_header Cross-Origin-Embedder-Policy require-corp;
-    add_header Cross-Origin-Resource-Policy same-origin;
-    add_header Cross-Origin-Opener-Policy same-origin;
-    add_header Referrer-Policy no-referrer;
-    add_header X-Content-Type-Options nosniff;
-    add_header X-Frame-Options deny;
-    add_header X-XSS-Protection "1; mode=block";
-
     location / {
+        # no-transform tells Cloudflare and others to not change the content of
+        # the file and thus breaking SRI.
+        # https://developers.cloudflare.com/cache/about/cache-control#other
+        add_header Cache-Control "public, max-age=3600, must-revalidate, no-transform";
+        add_header Cross-Origin-Embedder-Policy require-corp;
+        add_header Cross-Origin-Opener-Policy same-origin;
+        add_header Cross-Origin-Resource-Policy same-origin;
+        # opt-out of Google FloC
+        # https://developer.chrome.com/blog/floc/#how-can-websites-opt-out-of-the-floc-computation
+        add_header Permissions-Policy interest-cohort=();
+        add_header Referrer-Policy no-referrer;
+        add_header X-Content-Type-Options nosniff;
+        add_header X-Frame-Options deny;
+        add_header X-XSS-Protection "1; mode=block";
+
         include /etc/nginx/location.d/*.conf;
         try_files $uri $uri/ /index.php$is_args$args;
     }
@@ -28,15 +31,6 @@ server {
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         include fastcgi_params;
-
-        fastcgi_hide_header Cache-Control;
-        fastcgi_hide_header Cross-Origin-Embedder-Policy;
-        fastcgi_hide_header Cross-Origin-Resource-Policy;
-        fastcgi_hide_header Cross-Origin-Opener-Policy;
-        fastcgi_hide_header Referrer-Policy;
-        fastcgi_hide_header X-Content-Type-Options;
-        fastcgi_hide_header X-Frame-Options;
-        fastcgi_hide_header X-XSS-Protection;
 
         # Prevent exposing nginx + version to $_SERVER
         fastcgi_param SERVER_SOFTWARE "";


### PR DESCRIPTION
Fixes #79. Apart from moving the directive, I have to add the Cache-Control to the list of headers stripped from the fastcgi response, because we already set it on the PHP side:
https://github.com/PrivateBin/PrivateBin/blob/0fb104b1023bd361f32c2a014a98ec98a62c8267/lib/Controller.php#L339

Without the `fastcgi_hide_header`, the header gets sent twice, once from PHP and once from nginx:
```
$ docker build -t privatebin/nginx-fpm-alpine .
[...]
$ docker run -d --rm -p 8080:8080 --read-only --name privatebin privatebin/nginx-fpm-alpine:latest
$ curl -v http://localhost:8080/ 2>&1 | grep Cache-Control
< Cache-Control: no-store, no-cache, no-transform, must-revalidate
< Cache-Control: public, max-age=3600, must-revalidate, no-transform
```
With this proposed change, we get the same Cache-Control for js as well as other files:
```
$ curl -v http://localhost:8080/ 2>&1 | grep Cache-Control
< Cache-Control: public, max-age=3600, must-revalidate, no-transform
$ curl -v http://localhost:8080/js/privatebin.js 2>&1 | grep Cache-Control
< Cache-Control: public, max-age=3600, must-revalidate, no-transform
```