### PR TITLE
add a smoketest of the amd64 image, before pushing all archs

### DIFF
--- a/buildx.sh
+++ b/buildx.sh
@@ -12,7 +12,6 @@ EDGE=false
 build_image() {
     # shellcheck disable=SC2068
     docker build \
-        --platform linux/amd64,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le \
         --pull \
         --no-cache \
         --load \
@@ -24,6 +23,8 @@ push_image() {
     # shellcheck disable=SC2068
     docker buildx build \
         --platform linux/amd64,linux/386,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le \
+        --pull \
+        --no-cache \
         --push \
         $@ \
         .


### PR DESCRIPTION
Fixes #76, for now is limited to testing the amd64 image of the multi-arch build.