### PR TITLE
Cleanup edge build / improve smoke test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN \
 # Install dependencies
     && apk upgrade --no-cache \
     && apk add --no-cache gnupg git nginx php8-fpm php8-json php8-gd php8-opcache \
-        s6 ssl_client tzdata ${ALPINE_PACKAGES} ${ALPINE_COMPOSER_PACKAGES} \
+        s6 tzdata ${ALPINE_PACKAGES} ${ALPINE_COMPOSER_PACKAGES} \
 # Remove (some of the) default nginx config
     && rm -f /etc/nginx.conf /etc/nginx/http.d/default.conf /etc/php8/php-fpm.d/www.conf \
     && rm -rf /etc/nginx/sites-* \
@@ -78,7 +78,7 @@ RUN \
 # Clean up
     && gpgconf --kill gpg-agent \
     && rm -rf /tmp/* \
-    && apk del --no-cache gnupg git ssl_client ${ALPINE_COMPOSER_PACKAGES}
+    && apk del --no-cache gnupg git ${ALPINE_COMPOSER_PACKAGES}
 
 COPY etc/ /etc/
 

--- a/buildx.sh
+++ b/buildx.sh
@@ -82,7 +82,7 @@ main() {
     sleep 5 # give the services time to start up and the log to collect any errors that might occur
     test "$(docker inspect --format="{{.State.Running}}" smoketest)" = true
     curl --silent --show-error -o /dev/null http://127.0.0.1:8080/
-    if docker logs smoketest 2>&1 | grep -E "warn|emerg|fatal|panic"
+    if docker logs smoketest 2>&1 | grep -i -E "warn|emerg|fatal|panic|error"
     then
         exit 1
     fi


### PR DESCRIPTION
While testing with php81, currently only available in Alpine edge testing, for https://github.com/PrivateBin/PrivateBin/issues/875, I found that the ssl_client workaround for OpenSSL 3 is no longer needed and the smoke test fails to detect PHP errors, since it neither looks for "error" nor for upper case labels.