### PR TITLE
Remove now fixed excluded ZAP rules

### DIFF
--- a/.github/rules.tsv
+++ b/.github/rules.tsv
@@ -18,12 +18,6 @@
 #
 # false-positives
 #
-# we certainly don't use ASP.NET
-# reported: https://github.com/zaproxy/zaproxy/issues/6517
-40029	IGNORE	(Trace.axd Information Leak)
-# this is nginx, not Apache
-# reported: https://github.com/zaproxy/zaproxy/issues/6516
-10053	IGNORE	(Apache Range Header DoS (CVE-2011-3192))
 # again we return 200 to some strange URL
 90034	IGNORE	(Cloud Metadata Potentially Exposed)
 40035	IGNORE	(Hidden File Found)


### PR DESCRIPTION
According to the upstream issues these both should be fixed (and included in a release) and can thus be removed.