### PR TITLE
bump the alpine base image, ensures openssl 1.1.1n is installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.0
+FROM alpine:3.15.1
 
 ARG ALPINE_PACKAGES="php8-pdo_mysql php8-pdo_pgsql php8-openssl"
 ARG COMPOSER_PACKAGES=google/cloud-storage


### PR DESCRIPTION
This mitigates [CVE-2022-0778](https://security.alpinelinux.org/vuln/CVE-2022-0778). I'll tag this as 1.3.5-alpine3.15.1, which will push images of the same name to the container registry.