### PR TITLE
remove Permission-Policy header

### DIFF
--- a/etc/nginx/http.d/site.conf
+++ b/etc/nginx/http.d/site.conf
@@ -13,9 +13,6 @@ server {
         add_header Cross-Origin-Embedder-Policy require-corp;
         add_header Cross-Origin-Opener-Policy same-origin;
         add_header Cross-Origin-Resource-Policy same-origin;
-        # opt-out of Google FloC
-        # https://developer.chrome.com/blog/floc/#how-can-websites-opt-out-of-the-floc-computation
-        add_header Permissions-Policy interest-cohort=();
         add_header Referrer-Policy no-referrer;
         add_header X-Content-Type-Options nosniff;
         add_header X-Frame-Options deny;


### PR DESCRIPTION
This removal here only applies to the static resources, the PHP content gets this set on the application level:
https://github.com/PrivateBin/PrivateBin/commit/6f3bb25b092cf33160d1a8d2071f7ca4e5cedcaa

fixes #105 - The duplication of the header on privatebin.net was solved in:
https://github.com/PrivateBin/privatebin.info-pelican/commit/4f8bc79f6cbd926b0ee75e93317075c56cee669b