### PR TITLE
update PHP path on all root PHP files, not just index.php

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN \
     && rm *.md cfg/conf.sample.php \
     && mv cfg lib tpl vendor /srv \
     && mkdir -p /srv/data \
-    && sed -i "s#define('PATH', '');#define('PATH', '/srv/');#" index.php \
+    && sed -i "s#define('PATH', '');#define('PATH', '/srv/');#" *.php \
 # Support running s6 under a non-root user
     && mkdir -p /etc/s6/services/nginx/supervise /etc/s6/services/php-fpm8/supervise \
     && mkfifo \


### PR DESCRIPTION
https://github.com/PrivateBin/docker-nginx-fpm-alpine/issues/115

when implementing new PHP entry pages, i.e. to support server-side YOURLS interaction (see https://github.com/PrivateBin/PrivateBin/pull/997), new PHP root pages / entry points may be introduced in parallel to /index.php.

In order to fully integrate with the PrivateBin object classes, setting up the auto-loader like in index.php is desirable, but needs adjustment of the PATH setting similar to index.php (to point at the directory containing i.e. the class definitions).

This PR modifies Dockerfile to not only update index.php, but *.php in the root directory to set PATH according to the container's build layout.