### PR TITLE
support running new administrative scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ARG UID=65534
 ARG GID=82
 
 ENV CONFIG_PATH=/srv/cfg
+ENV PATH=$PATH:/srv/bin
 
 LABEL org.opencontainers.image.authors=support@privatebin.org \
       org.opencontainers.image.vendor=PrivateBin \
@@ -21,13 +22,13 @@ RUN \
     ALPINE_PACKAGES="$(echo ${ALPINE_PACKAGES} | sed 's/,/ /g')" ;\
     ALPINE_COMPOSER_PACKAGES="" ;\
     if [ -n "${COMPOSER_PACKAGES}" ] ; then \
-        ALPINE_COMPOSER_PACKAGES="php81 php81-curl php81-mbstring php81-phar" ;\
+        ALPINE_COMPOSER_PACKAGES="php81-curl php81-mbstring php81-phar" ;\
         RAWURL="$(echo ${PBURL} | sed s/github.com/raw.githubusercontent.com/)" ;\
     fi \
 # Install dependencies
     && apk upgrade --no-cache \
-    && apk add --no-cache gnupg git nginx php81-fpm php81-gd php81-opcache s6 \
-        tzdata ${ALPINE_PACKAGES} ${ALPINE_COMPOSER_PACKAGES} \
+    && apk add --no-cache gnupg git nginx php81 php81-fpm php81-gd php81-opcache \
+        s6 tzdata ${ALPINE_PACKAGES} ${ALPINE_COMPOSER_PACKAGES} \
 # Remove (some of the) default nginx config
     && rm -f /etc/nginx.conf /etc/nginx/http.d/default.conf /etc/php81/php-fpm.d/www.conf \
     && rm -rf /etc/nginx/sites-* \
@@ -65,7 +66,7 @@ RUN \
         rm composer.* /usr/local/bin/* ;\
     fi \
     && rm *.md cfg/conf.sample.php \
-    && mv cfg lib tpl vendor /srv \
+    && mv bin cfg lib tpl vendor /srv \
     && mkdir -p /srv/data \
     && sed -i "s#define('PATH', '');#define('PATH', '/srv/');#" index.php \
 # Support running s6 under a non-root user

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Note: The `Filesystem` data storage is supported out of the box. The image inclu
 
 ### Adjusting nginx or php-fpm settings
 
-You can attach your own `php.ini` or nginx configuration files to the folders `/etc/php81/conf.d/` and `/etc/nginx/conf.d/` respectively. This would for example let you adjust the maximum size these two services accept for file uploads, if you need more then the default 10 MiB.
+You can attach your own `php.ini` or nginx configuration files to the folders `/etc/php81/conf.d/` and `/etc/nginx/http.d/` respectively. This would for example let you adjust the maximum size these two services accept for file uploads, if you need more then the default 10 MiB.
 
 ### Timezone settings
 
@@ -137,6 +137,50 @@ spec:
 ```
 
 Note that the volume `privatebin-data` has to be a shared, persisted volume across all nodes, i.e. on an NFS share. As of PrivateBin 1.4.0 it is no longer required, when using a database or Google Cloud Storage.
+
+## Running administrative scripts
+
+The image includes two administrative scripts, which you can use to migrate from one storage backend to another, delete pastes by ID, removing empty directories when using the Filesystem backend, to purge all expired pastes and display statistics. These can be executed within the running image or by running the commands as alternative entrypoints with the same volumes attached as in the running service image, the former option is recommended.
+
+```
+# assuming you named your container "privatebin" using the option: --name privatebin
+
+docker exec -t privatebin administration --help
+Usage:
+  administration [--delete <paste id> | --empty-dirs | --help | --purge | --statistics]
+
+Options:
+  -d, --delete      deletes the requested paste ID
+  -e, --empty-dirs  removes empty directories (only if Filesystem storage is
+                    configured)
+  -h, --help        displays this help message
+  -p, --purge       purge all expired pastes
+  -s, --statistics  reads all stored pastes and comments and reports statistics
+
+docker exec -t privatebin migrate --help
+migrate - Copy data between PrivateBin backends
+
+Usage:
+  migrate [--delete-after] [--delete-during] [-f] [-n] [-v] srcconfdir
+          [<dstconfdir>]
+  migrate [-h|--help]
+
+Options:
+  --delete-after   delete data from source after all pastes and comments have
+                   successfully been copied to the destination
+  --delete-during  delete data from source after the current paste and its
+                   comments have successfully been copied to the destination
+  -f               forcefully overwrite data which already exists at the
+                   destination
+  -h, --help       displays this help message
+  -n               dry run, do not copy data
+  -v               be verbose
+  <srcconfdir>     use storage backend configration from conf.php found in
+                   this directory as source
+  <dstconfdir>     optionally, use storage backend configration from conf.php
+                   found in this directory as destination; defaults to:
+                   /srv/bin/../cfg/conf.php
+```
 
 ## Rolling your own image
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ Options:
                    /srv/bin/../cfg/conf.php
 ```
 
+Note that in order to migrate between different storage backends you will need to use the all-in-one image called `privatebin/nginx-fpm-alpine`, as it comes with all the drivers and libraries for the different supported backends. When using the variant images, you will only be able to migrate within two backends of the same storage type, for example two filesystem paths or two database backends.
+
 ## Rolling your own image
 
 To reproduce the image, run:


### PR DESCRIPTION
This change:
- moves the new administrative scripts out of web root (hardening)
- adds the php CLI package to the default packages
- adds the script location to the PATH
- provide some documentation on how to use them in the running container