### PR TITLE
clear up the build arg & tag logic

### DIFF
--- a/buildx.sh
+++ b/buildx.sh
@@ -69,8 +69,8 @@ main() {
             BUILD_ARGS=""
             ;;
     esac
-    IMAGE="privatebin/$IMAGE:"
-    IMAGE_TAGS="--tag $IMAGE:latest --tag $IMAGE:$TAG --tag ${IMAGE}:${TAG%%-*}"
+    IMAGE="privatebin/${IMAGE}:"
+    IMAGE_TAGS="--tag ${IMAGE}latest --tag ${IMAGE}${TAG} --tag ${IMAGE}${TAG%%-*}"
 
     if [ "$EDGE" = true ] ; then
         # build from alpine:edge instead of the stable release
@@ -78,12 +78,12 @@ main() {
         BUILD_ARGS+=" -f Dockerfile.edge"
 
         # replace the default tags, build just the edge one
-        IMAGE_TAGS="--tag $IMAGE:edge"
+        IMAGE_TAGS="--tag ${IMAGE}edge"
         IMAGE+="edge"
     else
         if [ "$EVENT" = push ] ; then
             # append the stable tag on explicit pushes to master or (git) tags
-            IMAGE_TAGS+=" --tag ${IMAGE}:stable"
+            IMAGE_TAGS+=" --tag ${IMAGE}stable"
         fi
         IMAGE+="latest"
     fi

--- a/buildx.sh
+++ b/buildx.sh
@@ -69,8 +69,8 @@ main() {
             BUILD_ARGS=""
             ;;
     esac
-    IMAGE="privatebin/${IMAGE}:"
-    IMAGE_TAGS="--tag ${IMAGE}latest --tag ${IMAGE}${TAG} --tag ${IMAGE}${TAG%%-*}"
+    IMAGE="privatebin/${IMAGE}"
+    IMAGE_TAGS="--tag ${IMAGE}:latest --tag ${IMAGE}:${TAG} --tag ${IMAGE}:${TAG%%-*}"
 
     if [ "${EDGE}" = true ] ; then
         # build from alpine:edge instead of the stable release
@@ -78,15 +78,15 @@ main() {
         BUILD_ARGS+=" -f Dockerfile.edge"
 
         # replace the default tags, build just the edge one
-        IMAGE_TAGS="--tag ${IMAGE}edge"
-        IMAGE+="edge"
+        IMAGE_TAGS="--tag ${IMAGE}:edge"
+        IMAGE+=":edge"
     else
         if [ "${EVENT}" = push ] ; then
             # append the stable tag on explicit pushes to master or (git) tags
-            IMAGE_TAGS+=" --tag ${IMAGE}stable"
+            IMAGE_TAGS+=" --tag ${IMAGE}:stable"
         fi
-        # always build latest on normal builds
-        IMAGE+="latest"
+        # always build latest on non-edge builds
+        IMAGE+=":latest"
     fi
     build_image "${BUILD_ARGS} ${IMAGE_TAGS}"
 

--- a/buildx.sh
+++ b/buildx.sh
@@ -85,6 +85,7 @@ main() {
             # append the stable tag on explicit pushes to master or (git) tags
             IMAGE_TAGS+=" --tag ${IMAGE}stable"
         fi
+        # always build latest on normal builds
         IMAGE+="latest"
     fi
     build_image "${BUILD_ARGS} ${IMAGE_TAGS}"

--- a/buildx.sh
+++ b/buildx.sh
@@ -101,7 +101,7 @@ main() {
 
     if is_image_push_required ; then
         docker_login
-        push_image "${BUILD_ARGS}"
+        push_image "${BUILD_ARGS} ${IMAGE_TAGS}"
     fi
 
     rm -f Dockerfile.edge "${HOME}/.docker/config.json"


### PR DESCRIPTION
Based on my mistake in https://github.com/PrivateBin/docker-nginx-fpm-alpine/pull/126#issuecomment-1364639264 and the discussion in https://github.com/PrivateBin/docker-nginx-fpm-alpine/commit/ac3b128bf69967c94a8e6c7e8bbf1f5926416fe9#r94178102 this logic may have grown to be a bit too complex or at least misleading.

My thinking here is that the build args and tag list are two different things, so maybe they would be best handled separately. I'm introducing default tags, which the "edge" case replaces and the "push" appends to. As we are explicitly in a bash script, I do make use of the `+=` bashism to append.