### PR TITLE
Fix polyfill errors when using S3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.17.1
 
 ARG ALPINE_PACKAGES="php81-pdo_mysql php81-pdo_pgsql php81-openssl php81-simplexml"
-ARG COMPOSER_PACKAGES="aws/aws-sdk-php google/cloud-storage"
+ARG COMPOSER_PACKAGES="aws/aws-sdk-php google/cloud-storage symfony/polyfill-iconv"
 ARG PBURL=https://github.com/PrivateBin/PrivateBin/
 ARG RELEASE=1.5.1
 ARG UID=65534


### PR DESCRIPTION
Hello,
I was getting the following error while trying to set up PrivateBin using local S3 in TrueNAS:
```
[error] 19#19: *1 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught Error: Call to undefined function Symfony\Polyfill\Mbstring\iconv_strlen() in /srv/vendor/symfony/polyfill-mbstring/Mbstring.php:491
Stack trace:
#0 /srv/vendor/symfony/polyfill-mbstring/bootstrap80.php(57): Symfony\Polyfill\Mbstring\Mbstring::mb_strlen()
#1 /srv/vendor/mtdowling/jmespath.php/src/Lexer.php(343): mb_strlen()
#2 /srv/vendor/mtdowling/jmespath.php/src/Parser.php(76): JmesPath\Lexer->tokenize()
#3 /srv/vendor/mtdowling/jmespath.php/src/AstRuntime.php(42): JmesPath\Parser->parse()
#4 /srv/vendor/mtdowling/jmespath.php/src/Env.php(33): JmesPath\AstRuntime->__invoke()
#5 /srv/vendor/aws/aws-sdk-php/src/Endpoint/PartitionEndpointProvider.php(117): JmesPath\Env::search()
#6 /srv/vendor/aws/aws-sdk-php/src/Endpoint/PartitionEndpointProvider.php(99): Aws\Endpoint\PartitionEndpointProvider::mergePrefixData()
#7 /srv/vendor/aws/aws-sdk-php/src/ClientResolver.php(981): Aws\Endpoint\PartitionEndpointProvider::defaultProvider()
#8 /srv/vendor/aws/aws-sdk-ph" while reading response header from upstream, client: x.x.x.x, server: , request: "POST / HTTP/1.1", upstream: "fastcgi://unix:/run/php-fpm.sock:", host: "xx.xx.xx"
```

Adding `symfony/polyfill-iconv` to the `COMPOSER_PACKAGES` seems to have resolved it and everything works flawlessly now.

Of course, if anyone has a better suggestion, feel free to share it :)