### PR TITLE
address S3 polyfill errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.17.1
 
-ARG ALPINE_PACKAGES="php81-pdo_mysql php81-pdo_pgsql php81-openssl php81-simplexml"
+ARG ALPINE_PACKAGES="php81-iconv php81-pdo_mysql php81-pdo_pgsql php81-openssl php81-simplexml"
 ARG COMPOSER_PACKAGES="aws/aws-sdk-php google/cloud-storage"
 ARG PBURL=https://github.com/PrivateBin/PrivateBin/
 ARG RELEASE=1.5.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.17.1
 
 ARG ALPINE_PACKAGES="php81-pdo_mysql php81-pdo_pgsql php81-openssl php81-simplexml"
-ARG COMPOSER_PACKAGES="aws/aws-sdk-php google/cloud-storage"
+ARG COMPOSER_PACKAGES="aws/aws-sdk-php google/cloud-storage symfony/polyfill-iconv"
 ARG PBURL=https://github.com/PrivateBin/PrivateBin/
 ARG RELEASE=1.5.1
 ARG UID=65534

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.17.1
 
 ARG ALPINE_PACKAGES="php81-pdo_mysql php81-pdo_pgsql php81-openssl php81-simplexml"
-ARG COMPOSER_PACKAGES="aws/aws-sdk-php google/cloud-storage symfony/polyfill-iconv"
+ARG COMPOSER_PACKAGES="aws/aws-sdk-php google/cloud-storage"
 ARG PBURL=https://github.com/PrivateBin/PrivateBin/
 ARG RELEASE=1.5.1
 ARG UID=65534

--- a/buildx.sh
+++ b/buildx.sh
@@ -63,7 +63,7 @@ main() {
             BUILD_ARGS="--build-arg ALPINE_PACKAGES=php81-pdo_mysql,php81-pdo_pgsql --build-arg COMPOSER_PACKAGES="
             ;;
         s3)
-            BUILD_ARGS="--build-arg ALPINE_PACKAGES=php81-curl,php81-openssl,php81-simplexml --build-arg COMPOSER_PACKAGES=aws/aws-sdk-php"
+            BUILD_ARGS="--build-arg ALPINE_PACKAGES=php81-curl,php81-mbstring,php81-openssl,php81-simplexml --build-arg COMPOSER_PACKAGES=aws/aws-sdk-php"
             ;;
         *)
             BUILD_ARGS=""


### PR DESCRIPTION
supersedes #134 - from that PR's discussion:

> The error itself does make sense, though, as we don't have the php81-iconv package installed, which seems to be required by the polyfill:
> https://github.com/symfony/polyfill-mbstring/blob/8ad114f6b39e2c98a8b0e3bd907732c207c2b534/Mbstring.php#L484-L492
> 
> We could install [php81-iconv](https://pkgs.alpinelinux.org/package/v3.17/community/x86_64/php81-iconv) (+88 kiB installed size) so the polyfill works or install [php81-mbstring](https://pkgs.alpinelinux.org/package/v3.17/community/x86_64/php81-mbstring) (+1.05 MB installed size for the library and +568 kiB for it's oniguruma dependency) to make the use of the polyfill unnecessary and provide native mbstring performance.
> 
> [...]
> 
> My idea is to install the lighter iconv package in the main image, which supports all backends and is therefore already pretty large and add the mbstrings to the dedicated S3 image, so it still gets any performance benefits that may bring over the php-based polyfill.