### PR TITLE
support AWS access tokens & some documentation

### DIFF
--- a/etc/php81/php-fpm.d/zz-docker.conf
+++ b/etc/php81/php-fpm.d/zz-docker.conf
@@ -12,8 +12,16 @@ pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
 
-env[PRIVATEBIN_GCS_BUCKET] = $PRIVATEBIN_GCS_BUCKET
+; Amazon Web Services variables used with S3 backend
+env[AWS_ACCESS_KEY_ID] = $AWS_ACCESS_KEY_ID
+env[AWS_SECRET_ACCESS_KEY] = $AWS_SECRET_ACCESS_KEY
+env[AWS_SESSION_TOKEN] = $AWS_SESSION_TOKEN
+
+; allows changing the default configuration path
+env[CONFIG_PATH] = $CONFIG_PATH
+
+; Google Cloud variables used with GCS backend
+env[GCLOUD_PROJECT] = $GCLOUD_PROJECT
 env[GOOGLE_APPLICATION_CREDENTIALS] = $GOOGLE_APPLICATION_CREDENTIALS
 env[GOOGLE_CLOUD_PROJECT] = $GOOGLE_CLOUD_PROJECT
-env[GCLOUD_PROJECT] = $GCLOUD_PROJECT
-env[CONFIG_PATH] = $CONFIG_PATH
+env[PRIVATEBIN_GCS_BUCKET] = $PRIVATEBIN_GCS_BUCKET


### PR DESCRIPTION
This is related to the new environment variables mentioned in [PR #1070](https://github.com/PrivateBin/PrivateBin/pull/1070/files#diff-6397c118bc734691db7f3ee3cb0612c97aaf098d404a4a6f430afed97ba1f1be) over in the main project.

In order to use these with the container image, they need to be passed down to PHP - for safety reasons, php-fpm filters out all environment variables and the ones to be exposed to PHP have to be configured explicitly.