### PR TITLE
Add commented HSTS line to nginx site.conf

### DIFF
--- a/etc/nginx/http.d/site.conf
+++ b/etc/nginx/http.d/site.conf
@@ -20,6 +20,10 @@ server {
         add_header X-Content-Type-Options nosniff;
         add_header X-Frame-Options deny;
         add_header X-XSS-Protection "1; mode=block";
+        
+        # Uncomment to enable HSTS
+        # https://www.nginx.com/blog/http-strict-transport-security-hsts-and-nginx/
+        #add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
         include /etc/nginx/location.d/*.conf;
         try_files $uri $uri/ /index.php$is_args$args;


### PR DESCRIPTION
The PrivateBin site says:
> Additionally the instance should be secured by [HSTS](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security).

So I figured I'd add a bit of documentation in case people want to enable HSTS for PrivateBin!