### PR TITLE
add ctype PHP extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,8 @@ RUN \
     fi \
 # Install dependencies
     && apk upgrade --no-cache \
-    && apk add --no-cache gnupg git nginx php83 php83-fpm php83-gd php83-opcache \
-        s6 tzdata ${ALPINE_PACKAGES} ${ALPINE_COMPOSER_PACKAGES} \
+    && apk add --no-cache gnupg git nginx php83 php83-ctype php83-fpm php83-gd \
+        php83-opcache s6 tzdata ${ALPINE_PACKAGES} ${ALPINE_COMPOSER_PACKAGES} \
 # Stabilize php config location
     && mv /etc/php83 /etc/php \
     && ln -s /etc/php /etc/php83 \


### PR DESCRIPTION
This will become required with the next PrivateBin release (> 1.7.1), where we replaced some of the regex based validation with ctype function calls.

It adds [about 50 KiB](https://pkgs.alpinelinux.org/package/v3.19/community/x86_64/php83-ctype) in uncompressed size.

We can merge this now or wait until the next release actually occurs. I would prefer merging it ahead of time.