### PR TITLE
with s6 2.13.1.0 binaries live in /usr/bin instead of /bin

### DIFF
--- a/etc/init.d/rc.local
+++ b/etc/init.d/rc.local
@@ -1,3 +1,3 @@
 #!/bin/execlineb -P
 foreground { cp -r /etc/s6/services /run }
-/bin/s6-svscan /run/services
+s6-svscan /run/services


### PR DESCRIPTION
This change makes the entrypoint script PATH dependent, but agnostic to the real location of the s6-svcscan binary, so it work both for alpine 3.20 as well as edge / future stable alpine releases. An alternative would be to detect the presence of the binary in /usr/bin and create a symlink to that into /bin.

Example failing nightly build: https://github.com/PrivateBin/docker-nginx-fpm-alpine/actions/runs/11376261631/job/31648434608

Caused by this change: https://gitlab.alpinelinux.org/alpine/aports/-/commit/d348893ddf28edb773ac69df7129b43b767d8418#bc2914fbfe731ad6ff1eb5c019c39433c87bcaf5_22_24