### PR TITLE
upgrade to PHP 8.4 packages

### DIFF
--- a/buildx.sh
+++ b/buildx.sh
@@ -52,13 +52,13 @@ main() {
             BUILD_ARGS="--build-arg ALPINE_PACKAGES= --build-arg COMPOSER_PACKAGES="
             ;;
         gcs)
-            BUILD_ARGS="--build-arg ALPINE_PACKAGES=php83-openssl --build-arg COMPOSER_PACKAGES=google/cloud-storage"
+            BUILD_ARGS="--build-arg ALPINE_PACKAGES=php84-openssl --build-arg COMPOSER_PACKAGES=google/cloud-storage"
             ;;
         pdo)
-            BUILD_ARGS="--build-arg ALPINE_PACKAGES=php83-pdo_mysql,php83-pdo_pgsql --build-arg COMPOSER_PACKAGES="
+            BUILD_ARGS="--build-arg ALPINE_PACKAGES=php84-pdo_mysql,php84-pdo_pgsql --build-arg COMPOSER_PACKAGES="
             ;;
         s3)
-            BUILD_ARGS="--build-arg ALPINE_PACKAGES=php83-curl,php83-mbstring,php83-openssl,php83-simplexml --build-arg COMPOSER_PACKAGES=aws/aws-sdk-php"
+            BUILD_ARGS="--build-arg ALPINE_PACKAGES=php84-curl,php84-mbstring,php84-openssl,php84-simplexml --build-arg COMPOSER_PACKAGES=aws/aws-sdk-php"
             ;;
         *)
             BUILD_ARGS=""

--- a/etc/s6/services/php-fpm84/run
+++ b/etc/s6/services/php-fpm84/run
@@ -1,2 +1,2 @@
 #!/bin/execlineb -P
-/usr/sbin/php-fpm83
+/usr/sbin/php-fpm84


### PR DESCRIPTION
composer related packages need to stay at PHP 8.3 until the composer package itself gets upgrade in Alpine. These 8.3 packages get removed again at the end of the image build. Closes #209.

When merged, I'll tag a separate release `1.7.6-alpine3.21-php8.4` so folks can choose that or the PHP 8.3 based `1.7.6-alpine3.21` image, in case there are any issues with it. As usual, we can't really test the cloud storage libraries ourselves and will have to rely on issue reports, should those libraries still not work on PHP 8.4.