### PR TITLE
upgrade to PHP 8.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.23
 
-ARG ALPINE_PACKAGES="php84-iconv php84-pdo_mysql php84-pdo_pgsql php84-openssl php84-simplexml"
+ARG ALPINE_PACKAGES="php85-iconv php85-pdo_mysql php85-pdo_pgsql php85-openssl php85-simplexml"
 ARG COMPOSER_PACKAGES="aws/aws-sdk-php google/cloud-storage"
 ARG PBURL=https://github.com/PrivateBin/PrivateBin/
 ARG RELEASE=2.0.3
@@ -24,26 +24,26 @@ RUN \
     ALPINE_PACKAGES="$(echo ${ALPINE_PACKAGES} | sed 's/,/ /g')" ;\
     ALPINE_COMPOSER_PACKAGES="" ;\
     if [ -n "${COMPOSER_PACKAGES}" ] ; then \
-        # we need these PHP 8.3 packages until composer gets updated to depend on PHP 8.4
+        # we need these PHP 8.4 packages until composer gets updated to depend on PHP 8.5
         ALPINE_COMPOSER_PACKAGES="composer" ;\
-        if [ -n "${ALPINE_PACKAGES##*php83-curl*}" ] ; then \
-            ALPINE_COMPOSER_PACKAGES="php83-curl ${ALPINE_COMPOSER_PACKAGES}" ;\
+        if [ -n "${ALPINE_PACKAGES##*php85-curl*}" ] ; then \
+            ALPINE_COMPOSER_PACKAGES="php84-curl ${ALPINE_COMPOSER_PACKAGES}" ;\
         fi ;\
-        if [ -n "${ALPINE_PACKAGES##*php83-mbstring*}" ] ; then \
-            ALPINE_COMPOSER_PACKAGES="php83-mbstring ${ALPINE_COMPOSER_PACKAGES}" ;\
+        if [ -n "${ALPINE_PACKAGES##*php85-mbstring*}" ] ; then \
+            ALPINE_COMPOSER_PACKAGES="php84-mbstring ${ALPINE_COMPOSER_PACKAGES}" ;\
         fi ;\
-        if [ -z "${ALPINE_PACKAGES##*php84-simplexml*}" ] ; then \
-            ALPINE_COMPOSER_PACKAGES="php83-simplexml ${ALPINE_COMPOSER_PACKAGES}" ;\
+        if [ -z "${ALPINE_PACKAGES##*php85-simplexml*}" ] ; then \
+            ALPINE_COMPOSER_PACKAGES="php84-simplexml ${ALPINE_COMPOSER_PACKAGES}" ;\
         fi ;\
     fi \
 # Install dependencies
     && apk upgrade --no-cache \
-    && apk add --no-cache gnupg git nginx php84 php84-ctype php84-fpm php84-gd \
-        php84-opcache s6 tzdata ${ALPINE_PACKAGES} ${ALPINE_COMPOSER_PACKAGES} \
+    && apk add --no-cache gnupg git nginx php85 php85-fpm php85-gd \
+        s6 tzdata ${ALPINE_PACKAGES} ${ALPINE_COMPOSER_PACKAGES} \
 # Stabilize php config location
-    && mv /etc/php84 /etc/php \
-    && ln -s /etc/php /etc/php84 \
-    && ln -s $(which php84) /usr/local/bin/php \
+    && mv /etc/php85 /etc/php \
+    && ln -s /etc/php /etc/php85 \
+    && ln -s $(which php85) /usr/local/bin/php \
 # Remove (some of the) default nginx & php config
     && rm -f /etc/nginx.conf /etc/nginx/http.d/default.conf /etc/php/php-fpm.d/www.conf \
     && rm -rf /etc/nginx/sites-* \
@@ -79,10 +79,10 @@ RUN \
     && mkdir -p /srv/data \
     && sed -i "s#define('PATH', '');#define('PATH', '/srv/');#" index.php \
 # Support running s6 under a non-root user
-    && mkdir -p /etc/s6/services/nginx/supervise /etc/s6/services/php-fpm84/supervise \
+    && mkdir -p /etc/s6/services/nginx/supervise /etc/s6/services/php-fpm85/supervise \
     && mkfifo \
         /etc/s6/services/nginx/supervise/control \
-        /etc/s6/services/php-fpm84/supervise/control \
+        /etc/s6/services/php-fpm85/supervise/control \
     && chown -R ${UID}:${GID} /etc/s6 /run /srv/* /var/lib/nginx /var/www \
     && chmod o+rwx /run /var/lib/nginx /var/lib/nginx/tmp \
 # Clean up

--- a/buildx.sh
+++ b/buildx.sh
@@ -52,13 +52,13 @@ main() {
             BUILD_ARGS="--build-arg ALPINE_PACKAGES= --build-arg COMPOSER_PACKAGES="
             ;;
         gcs)
-            BUILD_ARGS="--build-arg ALPINE_PACKAGES=php84-openssl --build-arg COMPOSER_PACKAGES=google/cloud-storage"
+            BUILD_ARGS="--build-arg ALPINE_PACKAGES=php85-openssl --build-arg COMPOSER_PACKAGES=google/cloud-storage"
             ;;
         pdo)
-            BUILD_ARGS="--build-arg ALPINE_PACKAGES=php84-pdo_mysql,php84-pdo_pgsql --build-arg COMPOSER_PACKAGES="
+            BUILD_ARGS="--build-arg ALPINE_PACKAGES=php85-pdo_mysql,php85-pdo_pgsql --build-arg COMPOSER_PACKAGES="
             ;;
         s3)
-            BUILD_ARGS="--build-arg ALPINE_PACKAGES=php84-curl,php84-mbstring,php84-openssl,php84-simplexml --build-arg COMPOSER_PACKAGES=aws/aws-sdk-php"
+            BUILD_ARGS="--build-arg ALPINE_PACKAGES=php85-curl,php85-mbstring,php85-openssl,php85-simplexml --build-arg COMPOSER_PACKAGES=aws/aws-sdk-php"
             ;;
         *)
             BUILD_ARGS=""

--- a/etc/s6/services/php-fpm85/run
+++ b/etc/s6/services/php-fpm85/run
@@ -1,2 +1,2 @@
 #!/bin/execlineb -P
-/usr/sbin/php-fpm84
+/usr/sbin/php-fpm85


### PR DESCRIPTION
- opcache is now a required module and included in php85
- composer now depends on PHP 8.4

As we found upstream that [PrivateBin 2.0.3 still emits some deprecation warnings under PHP 8.5](https://github.com/PrivateBin/PrivateBin/pull/1734), I would not merge this until we have released the fixes for those deprecation warnings, hence this is still marked as work-in-progress.