### PR TITLE
harden github actions

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -9,6 +9,8 @@ on:
     branches: master
     tags: '*'
 
+permissions: {}
+
 jobs:
   buildx:
     runs-on: ubuntu-latest
@@ -21,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
         with:

--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -2,7 +2,7 @@
 
 name: Security-scan
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   schedule:
     - cron: '0 3 * * *' # everyday at 03:00 UTC
@@ -14,6 +14,8 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
+permissions: {}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -27,8 +29,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: master
-    
+          persist-credentials: false
+
       # Runs a single command using the runners shell
       - name: Pull and start docker
         run: docker run -d --read-only -p 8080:8080 privatebin/nginx-fpm-alpine
@@ -38,9 +40,9 @@ jobs:
         uses: zaproxy/action-full-scan@v0.13.0
         with:
           # GitHub Token to create issues in the repository
-          #token: # optional, default is ${{ github.token }}
+          #token: # optional, default is github.token
           # Target URL
-          target: http://localhost:8080 
+          target: http://localhost:8080
           # Relative path of the ZAP configuration file
           rules_file_name: ".github/rules.tsv" # optional
           # The Docker file to be executed

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -12,9 +12,11 @@ jobs:
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v6
-      
+        with:
+          persist-credentials: false
+
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master

--- a/.github/workflows/snyk-container-analysis.yml
+++ b/.github/workflows/snyk-container-analysis.yml
@@ -14,11 +14,17 @@ on:
   schedule:
     - cron: '23 7 * * 5'
 
+permissions: {}
+
 jobs:
   snyk:
+    permissions:
+      security-events: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Build a Docker image
       run: docker build -t privatebin/nginx-fpm-alpine .
     - name: Run Snyk to check Docker image for vulnerabilities

--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -8,13 +8,19 @@ on:
   schedule:
     - cron: '20 13 * * 3'
 
+permissions: {}
+
 jobs:
   build:
     name: Trivy analysis
+    permissions:
+      security-events: write
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Build an image from Dockerfile
         run: |


### PR DESCRIPTION
- restrict all default permissions
- content: read is not necessary for public repos
- security-events: write is needed for CodeQL uploads of SARIF reports
- persist-credentials: false prevents any github token to remain configured in the checked out repo (not necessary when not intending to push from the action)