### PR TITLE
remove deprecated buildx action option

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -33,8 +33,6 @@ jobs:
           platforms: linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-        with:
-          install: true
       - name: Login to DockerHub
         uses: docker/login-action@v4
         if: ${{ github.event_name != 'pull_request' && (github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')) }}


### PR DESCRIPTION
no longer supported, simply causes a warning in the post action

See: https://github.com/docker/setup-buildx-action/pull/455